### PR TITLE
Only use Interface if it is set

### DIFF
--- a/libtwitcurl/twitcurl.cpp
+++ b/libtwitcurl/twitcurl.cpp
@@ -1695,9 +1695,12 @@ void twitCurl::prepareCurlInterface()
     /* Reset existing interface details in cURL */
     curl_easy_setopt( m_curlHandle, CURLOPT_INTERFACE, NULL );
     
-    /* Set interface details in cURL */
-    curl_easy_setopt( m_curlHandle, CURLOPT_INTERFACE, m_Interface.c_str() );
-
+    if( m_Interface.length() )
+    {
+    	/* Set interface details in cURL */
+    	curl_easy_setopt( m_curlHandle, CURLOPT_INTERFACE, m_Interface.c_str() );
+    }
+    
     /* Set the flag to true indicating that proxy info is set in cURL */
     m_curlInterfaseParamSet = true;
 }


### PR DESCRIPTION
I am so sorry, I forgot to put this condition, Interface must only be set if the parameter exists, otherwise curl will fail