### PR TITLE
Allow search query string include special characters such as blank, '?', '&'

### DIFF
--- a/libtwitcurl/oauthlib.cpp
+++ b/libtwitcurl/oauthlib.cpp
@@ -265,6 +265,42 @@ void oAuth::generateNonceTimeStamp()
 }
 
 /*++
+* @method: oAuth::buildOAuthHttpParameterKeyValPairs
+*
+* @description: this method prepares key-value pairs from the data part of the URL
+*               parameters, as required by OAuth header and signature generation.
+*
+* @input: params - HTTP url parameters.
+*         urlencodeData - If true, string will be urlencoded before converting
+*                         to key value pairs.
+*
+* @output: rawDataKeyValuePairs - Map in which key-value pairs are populated
+*
+* @remarks: internal method
+*
+*--*/
+void oAuth::buildOAuthHttpParameterKeyValPairs(const httpParams& params,
+                                          bool urlencodeData,
+                                          oAuthKeyValuePairs& rawDataKeyValuePairs )
+{
+    if (params.empty())
+    {
+        return;
+    }
+
+    std::string dataKey;
+    std::string dataVal;
+
+    for ( int i = 0; i < params.size(); i++ ) {
+        dataKey = params.at(i).key;
+        dataVal = params.at(i).value;
+
+        /* Put this key=value pair in map */
+        rawDataKeyValuePairs[dataKey] = urlencodeData ? urlencode(dataVal) : dataVal;
+    }    
+}
+
+/*++
 * @method: oAuth::buildOAuthRawDataKeyValPairs
 *
 * @description: this method prepares key-value pairs from the data part of the URL
@@ -494,6 +530,7 @@ bool oAuth::getSignature( const eOAuthHttpRequestType eType,
 *
 * @input: eType - HTTP request type
 *         rawUrl - raw url of the HTTP request
+*         params - HTTP url parameters
 *         rawData - HTTP data (post fields)
 *         includeOAuthVerifierPin - flag to indicate whether or not oauth_verifier needs to included
 *                                   in OAuth header
@@ -503,6 +540,7 @@ bool oAuth::getSignature( const eOAuthHttpRequestType eType,
 *--*/
 bool oAuth::getOAuthHeader( const eOAuthHttpRequestType eType,
                             const std::string& rawUrl,
+                            const httpParams& params,
                             const std::string& rawData,
                             std::string& oAuthHttpHeader,
                             const bool includeOAuthVerifierPin )
@@ -530,6 +568,8 @@ bool oAuth::getOAuthHeader( const eOAuthHttpRequestType eType,
         /* Split the data in URL as key=value pairs */
         buildOAuthRawDataKeyValPairs( dataPart, true, rawKeyValuePairs );
     }
+    buildOAuthHttpParameterKeyValPairs(params, true, rawKeyValuePairs);
+
 
     /* Split the raw data if it's present, as key=value pairs. Data should already be urlencoded once */
     buildOAuthRawDataKeyValPairs( rawData, false, rawKeyValuePairs );

--- a/libtwitcurl/oauthlib.h
+++ b/libtwitcurl/oauthlib.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <list>
 #include <map>
+#include <vector>
 
 typedef enum _eOAuthHttpRequestType
 {
@@ -20,6 +21,13 @@ typedef enum _eOAuthHttpRequestType
 
 typedef std::list<std::string> oAuthKeyValueList;
 typedef std::map<std::string, std::string> oAuthKeyValuePairs;
+
+typedef struct
+{
+    std::string key;
+    std::string value;
+} httpParamPair;
+typedef std::vector<httpParamPair> httpParams;
 
 class oAuth
 {
@@ -48,6 +56,7 @@ public:
 
     bool getOAuthHeader( const eOAuthHttpRequestType eType, /* in */
                          const std::string& rawUrl, /* in */
+                         const httpParams& params, /* in */
                          const std::string& rawData, /* in */
                          std::string& oAuthHttpHeader, /* out */
                          const bool includeOAuthVerifierPin = false /* in */ );
@@ -72,6 +81,10 @@ private:
     void buildOAuthRawDataKeyValPairs( const std::string& rawData, /* in */
                                        bool urlencodeData, /* in */
                                        oAuthKeyValuePairs& rawDataKeyValuePairs /* out */ );
+
+    void buildOAuthHttpParameterKeyValPairs(const httpParams& params, /* in */
+                                            bool urlencodeData, /* in */
+                                            oAuthKeyValuePairs& rawDataKeyValuePairs /* out */);
 
     bool buildOAuthTokenKeyValuePairs( const bool includeOAuthVerifierPin, /* in */
                                        const std::string& oauthSignature, /* in */

--- a/libtwitcurl/twitcurl.cpp
+++ b/libtwitcurl/twitcurl.cpp
@@ -1,5 +1,6 @@
 #define NOMINMAX
 #include <memory.h>
+#include <algorithm>
 #include "twitcurlurls.h"
 #include "twitcurl.h"
 #include "urlencode.h"
@@ -383,22 +384,28 @@ void twitCurl::setInterface( const std::string& Interface )
 *--*/
 bool twitCurl::search( const std::string& searchQuery, const std::string resultCount )
 {
+    httpParams params;
     /* Prepare URL */
     std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
                            twitterDefaults::TWITCURL_SEARCH_URL +
-                           twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType] +
-                           twitCurlDefaults::TWITCURL_URL_SEP_QUES + twitCurlDefaults::TWITCURL_SEARCHQUERYSTRING +
-                           searchQuery;
+                           twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
+
+    httpParamPair searchQueryParam;
+    searchQueryParam.key = twitCurlDefaults::TWITCURL_SEARCHQUERYSTRING;
+    searchQueryParam.value = searchQuery;
+    params.push_back( searchQueryParam );
 
     /* Add number of results count if provided */
     if( resultCount.size() )
     {
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_AMP +
-                    twitCurlDefaults::TWITCURL_COUNT + urlencode( resultCount );
+        httpParamPair tweetCountParam;
+        tweetCountParam.key = twitCurlDefaults::TWITCURL_COUNT;
+        tweetCountParam.value = resultCount;
+        params.push_back( tweetCountParam );
     }
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -421,13 +428,16 @@ bool twitCurl::statusUpdate( const std::string& newStatus, const std::string inR
     }
 
     /* Prepare new status message */
-    std::string newStatusMsg = twitCurlDefaults::TWITCURL_STATUSSTRING + urlencode( newStatus );
+    std::string newStatusMsg = twitCurlDefaults::TWITCURL_STATUSSTRING +
+                               twitCurlDefaults::TWITCURL_URL_EQUAL +
+                               urlencode( newStatus );
 
     /* Append status id to which we're replying to */
     if( inReplyToStatusId.size() )
     {
         newStatusMsg += twitCurlDefaults::TWITCURL_URL_SEP_AMP +
                         twitCurlDefaults::TWITCURL_INREPLYTOSTATUSID +
+                        twitCurlDefaults::TWITCURL_URL_EQUAL +
                         urlencode( inReplyToStatusId );
     }
 
@@ -517,6 +527,7 @@ bool twitCurl::retweetById( const std::string& statusId )
 
     /* Send some dummy data in POST */
     std::string dummyData = twitCurlDefaults::TWITCURL_TEXTSTRING +
+                            twitCurlDefaults::TWITCURL_URL_EQUAL +
                             urlencode( std::string( "dummy" ) );
 
     /* Perform Retweet */
@@ -536,16 +547,20 @@ bool twitCurl::retweetById( const std::string& statusId )
 *--*/
 bool twitCurl::timelineHomeGet( const std::string sinceId )
 {
+    httpParams params;
     std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
                            twitterDefaults::TWITCURL_HOME_TIMELINE_URL +
                            twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
     if( sinceId.length() )
     {
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_QUES + twitCurlDefaults::TWITCURL_SINCEID + sinceId;
+        httpParamPair sinceIdParam;
+        sinceIdParam.key = twitCurlDefaults::TWITCURL_SINCEID;
+        sinceIdParam.value = sinceId;
+        params.push_back( sinceIdParam );
     }
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -618,16 +633,20 @@ bool twitCurl::timelineFriendsGet()
 *--*/
 bool twitCurl::mentionsGet( const std::string sinceId )
 {
+    httpParams params;
     std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
                            twitterDefaults::TWITCURL_MENTIONS_URL +
                            twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
     if( sinceId.length() )
     {
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_QUES + twitCurlDefaults::TWITCURL_SINCEID + sinceId;
+        httpParamPair sinceIdParam;
+        sinceIdParam.key = twitCurlDefaults::TWITCURL_SINCEID;
+        sinceIdParam.value = sinceId;
+        params.push_back( sinceIdParam );
     }
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -650,46 +669,49 @@ bool twitCurl::timelineUserGet( const bool trimUser,
                                 const std::string userInfo,
                                 const bool isUserId )
 {
+    httpParams params;
     /* Prepare URL */
-    std::string buildUrl;
+    std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
+                           twitterDefaults::TWITCURL_USERTIMELINE_URL +
+                           twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
 
-    utilMakeUrlForUser( buildUrl, twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
-                        twitterDefaults::TWITCURL_USERTIMELINE_URL +
-                        twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType],
-                        userInfo, isUserId );
+    httpParamPair userInfoParam;
+    userInfoParam.key = isUserId ? twitCurlDefaults::TWITCURL_USERID : twitCurlDefaults::TWITCURL_SCREENNAME;
+    userInfoParam.value = userInfo;
+    params.push_back( userInfoParam );
 
-    if( userInfo.empty() )
-    {
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_QUES;
-    }
 
     if( tweetCount )
     {
-		std::stringstream tmpStrm;
-        if( tweetCount < twitCurlDefaults::MAX_TIMELINE_TWEET_COUNT )
-        {
-            tmpStrm << twitCurlDefaults::TWITCURL_URL_SEP_AMP + twitCurlDefaults::TWITCURL_COUNT << tweetCount;
-        }
+        httpParamPair tweetCountParam;
+        tweetCountParam.key = twitCurlDefaults::TWITCURL_COUNT;
+        std::ostringstream os;
+        if (tweetCount < twitCurlDefaults::MAX_TIMELINE_TWEET_COUNT)
+            os << tweetCount;
         else
-        {
-            tmpStrm << twitCurlDefaults::TWITCURL_URL_SEP_AMP + twitCurlDefaults::TWITCURL_COUNT << twitCurlDefaults::MAX_TIMELINE_TWEET_COUNT;
-        }
-        buildUrl += tmpStrm.str();
-        tmpStrm.str().clear();
+            os << twitCurlDefaults::MAX_TIMELINE_TWEET_COUNT;
+        tweetCountParam.value = os.str();
+        params.push_back( tweetCountParam );
     }
 
     if( includeRetweets )
     {
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_AMP + twitCurlDefaults::TWITCURL_INCRETWEETS;
+        httpParamPair includeRetweetParam;
+        includeRetweetParam.key = twitCurlDefaults::TWITCURL_INCRETWEETS;
+        includeRetweetParam.value = std::string( "true" );
+        params.push_back( includeRetweetParam );
     }
 
     if( trimUser )
     {
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_AMP + twitCurlDefaults::TWITCURL_TRIMUSER;
+        httpParamPair trimUserParam;
+        trimUserParam.key = twitCurlDefaults::TWITCURL_TRIMUSER;
+        trimUserParam.value = std::string( "true" );
+        params.push_back( trimUserParam );
     }
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -718,15 +740,15 @@ bool twitCurl::userLookup( const std::vector<std::string> &userInfo, const bool 
         userIds += sep + userInfo[i];
     }
 
-    userIds = ( isUserId ? twitCurlDefaults::TWITCURL_USERID : twitCurlDefaults::TWITCURL_SCREENNAME ) +
-              urlencode( userIds );
+    userIds = ( isUserId ? twitCurlDefaults::TWITCURL_USERID : twitCurlDefaults::TWITCURL_SCREENNAME) +
+               twitCurlDefaults::TWITCURL_URL_EQUAL + urlencode( userIds );
 
-    std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] + 
-                           twitterDefaults::TWITCURL_LOOKUPUSERS_URL + 
+    std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
+                           twitterDefaults::TWITCURL_LOOKUPUSERS_URL +
                            twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
 
     /* Perform POST */
-    return performPost( buildUrl, userIds);
+    return performPost( buildUrl, userIds );
 }
 
 /*++
@@ -743,20 +765,23 @@ bool twitCurl::userLookup( const std::vector<std::string> &userInfo, const bool 
 *--*/
 bool twitCurl::userGet( const std::string& userInfo, const bool isUserId )
 {
+    httpParams params;
     if( userInfo.empty() )
     {
         return false;
     }
 
     /* Set URL */
-    std::string buildUrl;
-    utilMakeUrlForUser( buildUrl, twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
-                        twitterDefaults::TWITCURL_SHOWUSERS_URL +
-                        twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType],
-                        userInfo, isUserId );
+    std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
+                           twitterDefaults::TWITCURL_SHOWUSERS_URL +
+                           twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
+    httpParamPair userInfoParam;
+    userInfoParam.key = isUserId ? twitCurlDefaults::TWITCURL_USERID : twitCurlDefaults::TWITCURL_SCREENNAME;
+    userInfoParam.value = userInfo;
+    params.push_back( userInfoParam );
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -773,15 +798,18 @@ bool twitCurl::userGet( const std::string& userInfo, const bool isUserId )
 *--*/
 bool twitCurl::friendsGet( const std::string userInfo, const bool isUserId )
 {
+    httpParams params;
     /* Set URL */
-    std::string buildUrl;
-    utilMakeUrlForUser( buildUrl, twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
-                        twitterDefaults::TWITCURL_SHOWFRIENDS_URL +
-                        twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType],
-                        userInfo, isUserId );
+    std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
+                           twitterDefaults::TWITCURL_SHOWFRIENDS_URL +
+                           twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
+    httpParamPair userInfoParam;
+    userInfoParam.key = isUserId ? twitCurlDefaults::TWITCURL_USERID : twitCurlDefaults::TWITCURL_SCREENNAME;
+    userInfoParam.value = userInfo;
+    params.push_back( userInfoParam );
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -798,15 +826,19 @@ bool twitCurl::friendsGet( const std::string userInfo, const bool isUserId )
 *--*/
 bool twitCurl::followersGet( const std::string userInfo, const bool isUserId )
 {
+    httpParams params;
     /* Prepare URL */
-    std::string buildUrl;
-    utilMakeUrlForUser( buildUrl, twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
-                        twitterDefaults::TWITCURL_SHOWFOLLOWERS_URL +
-                        twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType],
-                        userInfo, isUserId );
+    std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
+                           twitterDefaults::TWITCURL_SHOWFOLLOWERS_URL +
+                           twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
+
+    httpParamPair userInfoParam;
+    userInfoParam.key = isUserId ? twitCurlDefaults::TWITCURL_USERID : twitCurlDefaults::TWITCURL_SCREENNAME;
+    userInfoParam.value = userInfo;
+    params.push_back( userInfoParam );
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -822,17 +854,21 @@ bool twitCurl::followersGet( const std::string userInfo, const bool isUserId )
 *--*/
 bool twitCurl::directMessageGet( const std::string sinceId )
 {
+    httpParams params;
     std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
                            twitterDefaults::TWITCURL_DIRECTMESSAGES_URL +
                            twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
 
     if( sinceId.length() )
     {
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_QUES + twitCurlDefaults::TWITCURL_SINCEID + sinceId;
+        httpParamPair sinceIdParam;
+        sinceIdParam.key = twitCurlDefaults::TWITCURL_SINCEID;
+        sinceIdParam.value = sinceId;
+        params.push_back( sinceIdParam );
     }
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -856,7 +892,9 @@ bool twitCurl::directMessageSend( const std::string& userInfo, const std::string
     }
 
     /* Prepare new direct message */
-    std::string newDm = twitCurlDefaults::TWITCURL_TEXTSTRING + urlencode( dMsg );
+    std::string newDm = twitCurlDefaults::TWITCURL_TEXTSTRING +
+                        twitCurlDefaults::TWITCURL_URL_EQUAL +
+                        urlencode(dMsg);
 
     /* Prepare URL */
     std::string buildUrl;
@@ -943,6 +981,7 @@ bool twitCurl::friendshipCreate( const std::string& userInfo, const bool isUserI
 
     /* Send some dummy data in POST */
     std::string dummyData = twitCurlDefaults::TWITCURL_TEXTSTRING +
+                            twitCurlDefaults::TWITCURL_URL_EQUAL +
                             urlencode( std::string( "dummy" ) );
 
     /* Perform POST */
@@ -993,27 +1032,21 @@ bool twitCurl::friendshipDestroy( const std::string& userInfo, const bool isUser
 *--*/
 bool twitCurl::friendshipShow( const std::string& userInfo, const bool isUserId )
 {
+    httpParams params;
     /* Prepare URL */
     std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
                            twitterDefaults::TWITCURL_FRIENDSHIPSSHOW_URL +
                            twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
     if( userInfo.length() )
     {
-        /* Append username to the URL */
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_QUES;
-        if( isUserId )
-        {
-            buildUrl += twitCurlDefaults::TWITCURL_TARGETUSERID;
-        }
-        else
-        {
-            buildUrl += twitCurlDefaults::TWITCURL_TARGETSCREENNAME;
-        }
-        buildUrl += userInfo;
+        httpParamPair userInfoParam;
+        userInfoParam.key = isUserId ? twitCurlDefaults::TWITCURL_TARGETUSERID : twitCurlDefaults::TWITCURL_TARGETSCREENNAME;
+        userInfoParam.value = userInfo;
+        params.push_back( userInfoParam );
     }
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -1032,22 +1065,27 @@ bool twitCurl::friendshipShow( const std::string& userInfo, const bool isUserId 
 *--*/
 bool twitCurl::friendsIdsGet( const std::string& nextCursor, const std::string& userInfo, const bool isUserId )
 {
+    httpParams params;
     /* Prepare URL */
-    std::string buildUrl;
-    utilMakeUrlForUser( buildUrl, twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
-                        twitterDefaults::TWITCURL_FRIENDSIDS_URL +
-                        twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType],
-                        userInfo, isUserId );
+    std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
+                           twitterDefaults::TWITCURL_FRIENDSIDS_URL +
+                           twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
 
-    if( buildUrl.length() && nextCursor.length() )
+    httpParamPair userInfoParam;
+    userInfoParam.key = isUserId ? twitCurlDefaults::TWITCURL_USERID : twitCurlDefaults::TWITCURL_SCREENNAME;
+    userInfoParam.value = userInfo;
+    params.push_back( userInfoParam );
+
+    if( nextCursor.length() )
     {
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_AMP +
-                    twitCurlDefaults::TWITCURL_NEXT_CURSOR +
-                    nextCursor;
+        httpParamPair nextCursorParam;
+        nextCursorParam.key = twitCurlDefaults::TWITCURL_NEXT_CURSOR;
+        nextCursorParam.value = nextCursor;
+        params.push_back( nextCursorParam );
     }
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -1066,22 +1104,27 @@ bool twitCurl::friendsIdsGet( const std::string& nextCursor, const std::string& 
 *--*/
 bool twitCurl::followersIdsGet( const std::string& nextCursor, const std::string& userInfo, const bool isUserId )
 {
+    httpParams params;
     /* Prepare URL */
-    std::string buildUrl;
-    utilMakeUrlForUser( buildUrl, twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
-                        twitterDefaults::TWITCURL_FOLLOWERSIDS_URL +
-                        twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType],
-                        userInfo, isUserId );
+    std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
+                           twitterDefaults::TWITCURL_FOLLOWERSIDS_URL +
+                           twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
+
+    httpParamPair userInfoParam;
+    userInfoParam.key = isUserId ? twitCurlDefaults::TWITCURL_USERID : twitCurlDefaults::TWITCURL_SCREENNAME;
+    userInfoParam.value = userInfo;
+    params.push_back( userInfoParam );
 
     if( buildUrl.length() && nextCursor.length() )
     {
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_AMP +
-                    twitCurlDefaults::TWITCURL_NEXT_CURSOR +
-                    nextCursor;
+        httpParamPair nextCursorParam;
+        nextCursorParam.key = twitCurlDefaults::TWITCURL_NEXT_CURSOR;
+        nextCursorParam.value = nextCursor;
+        params.push_back( nextCursorParam );
     }
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -1161,6 +1204,7 @@ bool twitCurl::favoriteCreate( const std::string& statusId )
 
     /* Send some dummy data in POST */
     std::string dummyData = twitCurlDefaults::TWITCURL_TEXTSTRING +
+                            twitCurlDefaults::TWITCURL_URL_EQUAL +
                             urlencode( std::string( "dummy" ) );
 
     /* Perform POST */
@@ -1202,17 +1246,18 @@ bool twitCurl::favoriteDestroy( const std::string& statusId )
 *--*/
 bool twitCurl::blockCreate( const std::string& userInfo )
 {
-        /* Prepare URL */
-        std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
-                               twitterDefaults::TWITCURL_BLOCKSCREATE_URL + userInfo +
-                               twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
+    /* Prepare URL */
+    std::string buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
+                           twitterDefaults::TWITCURL_BLOCKSCREATE_URL + userInfo +
+                           twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
 
-        /* Send some dummy data in POST */
-        std::string dummyData = twitCurlDefaults::TWITCURL_TEXTSTRING +
-                                urlencode( std::string( "dummy" ) );
+    /* Send some dummy data in POST */
+    std::string dummyData = twitCurlDefaults::TWITCURL_TEXTSTRING +
+                            twitCurlDefaults::TWITCURL_URL_EQUAL +
+                            urlencode(std::string("dummy"));
 
-        /* Perform POST */
-        return performPost( buildUrl, dummyData );
+    /* Perform POST */
+    return performPost( buildUrl, dummyData );
 }
 
 /*++
@@ -1253,39 +1298,38 @@ bool twitCurl::blockDestroy( const std::string& userInfo )
 *--*/
 bool twitCurl::blockListGet( const std::string& nextCursor, const bool includeEntities, const bool skipStatus )
 {
+    httpParams params;
     /* Prepare URL */
-    std::string buildUrl, urlParams;
+    std::string buildUrl;
 
     buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
                twitterDefaults::TWITCURL_BLOCKSLIST_URL +
                twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
     if( includeEntities )
     {
-        urlParams += twitCurlDefaults::TWITCURL_INCLUDE_ENTITIES + std::string("true");
+        httpParamPair includeEntitiesParam;
+        includeEntitiesParam.key = twitCurlDefaults::TWITCURL_INCLUDE_ENTITIES;
+        includeEntitiesParam.value = std::string( "true" );
+        params.push_back( includeEntitiesParam );
     }
     if( skipStatus )
     {
-        if( urlParams.length() )
-        {
-            urlParams += twitCurlDefaults::TWITCURL_URL_SEP_AMP;
-        }
-        urlParams += twitCurlDefaults::TWITCURL_SKIP_STATUS + std::string("true");
+        httpParamPair skipStatusParam;
+        skipStatusParam.key = twitCurlDefaults::TWITCURL_SKIP_STATUS;
+        skipStatusParam.value = std::string( "true" );
+        params.push_back( skipStatusParam );
     }
     if( nextCursor.length() )
     {
-        if( urlParams.length() )
-        {
-            urlParams += twitCurlDefaults::TWITCURL_URL_SEP_AMP;
-        }
-        urlParams += twitCurlDefaults::TWITCURL_NEXT_CURSOR + nextCursor;
-    }
-    if( urlParams.length() )
-    {
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_QUES + urlParams;
+        httpParamPair nextCursorParam;
+        nextCursorParam.key = twitCurlDefaults::TWITCURL_NEXT_CURSOR;
+        nextCursorParam.value = nextCursor;
+        params.push_back( nextCursorParam );
     }
 
+
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -1304,31 +1348,30 @@ bool twitCurl::blockListGet( const std::string& nextCursor, const bool includeEn
 *--*/
 bool twitCurl::blockIdsGet( const std::string& nextCursor, const bool stringifyIds )
 {
+    httpParams params;
     /* Prepare URL */
-    std::string buildUrl, urlParams;
+    std::string buildUrl;
 
     buildUrl = twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
                twitterDefaults::TWITCURL_BLOCKSIDS_URL +
                twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
     if( stringifyIds )
     {
-        urlParams += twitCurlDefaults::TWITCURL_STRINGIFY_IDS + std::string("true");
+        httpParamPair stringifyIdsParam;
+        stringifyIdsParam.key = twitCurlDefaults::TWITCURL_STRINGIFY_IDS;
+        stringifyIdsParam.value = std::string("true");
+        params.push_back( stringifyIdsParam );
     }
     if( nextCursor.length() )
     {
-        if( urlParams.length() )
-        {
-            urlParams += twitCurlDefaults::TWITCURL_URL_SEP_AMP;
-        }
-        urlParams += twitCurlDefaults::TWITCURL_NEXT_CURSOR + nextCursor;
-    }
-    if( urlParams.length() )
-    {
-        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_QUES + urlParams;
+        httpParamPair nextCursorParam;
+        nextCursorParam.key = twitCurlDefaults::TWITCURL_NEXT_CURSOR;
+        nextCursorParam.value = nextCursor;
+        params.push_back( nextCursorParam );
     }
 
     /* Perform GET */
-    return performGet( buildUrl );
+    return performGet( buildUrl, params );
 }
 
 /*++
@@ -1392,7 +1435,9 @@ bool twitCurl::savedSearchCreate( const std::string& query )
                            twitCurlDefaults::TWITCURL_EXTENSIONFORMATS[m_eApiFormatType];
 
     /* Send some dummy data in POST */
-    std::string queryStr = twitCurlDefaults::TWITCURL_QUERYSTRING + urlencode( query );
+    std::string queryStr = twitCurlDefaults::TWITCURL_QUERYSTRING +
+                           twitCurlDefaults::TWITCURL_URL_EQUAL +
+                           urlencode(query);
 
     /* Perform POST */
     return performPost( buildUrl, queryStr );
@@ -1817,13 +1862,14 @@ void twitCurl::prepareStandardParams()
 *               twitcurl users should not use this method.
 *
 * @input: getUrl - url
+* @input: params - HTTP url parameters
 *
 * @output: none
 *
 * @remarks: internal method
 *
 *--*/
-bool twitCurl::performGet( const std::string& getUrl )
+bool twitCurl::performGet( const std::string& getUrl, const httpParams& params )
 {
     /* Return if cURL is not initialized */
     if( !isCurlInit() )
@@ -1834,12 +1880,13 @@ bool twitCurl::performGet( const std::string& getUrl )
     std::string dataStrDummy;
     std::string oAuthHttpHeader;
     struct curl_slist* pOAuthHeaderList = NULL;
+    std::string encodedUrl = std::string(getUrl);
 
     /* Prepare standard params */
     prepareStandardParams();
 
     /* Set OAuth header */
-    m_oAuth.getOAuthHeader( eOAuthHttpGet, getUrl, dataStrDummy, oAuthHttpHeader );
+    m_oAuth.getOAuthHeader( eOAuthHttpGet, getUrl, params, dataStrDummy, oAuthHttpHeader );
     if( oAuthHttpHeader.length() )
     {
         pOAuthHeaderList = curl_slist_append( pOAuthHeaderList, oAuthHttpHeader.c_str() );
@@ -1853,20 +1900,54 @@ bool twitCurl::performGet( const std::string& getUrl )
     curl_easy_setopt( m_curlHandle, CURLOPT_HTTPGET, 1 );
     curl_easy_setopt( m_curlHandle, CURLOPT_URL, getUrl.c_str() );
 
-    /* Send http request */
-    if( CURLE_OK == curl_easy_perform( m_curlHandle ) )
+    if( !params.empty() )
     {
-        if( pOAuthHeaderList )
+        size_t nPos = getUrl.find_first_of( twitCurlDefaults::TWITCURL_URL_SEP_QUES );
+        if( std::string::npos == nPos )
         {
-            curl_slist_free_all( pOAuthHeaderList );
+            encodedUrl.append( twitCurlDefaults::TWITCURL_URL_SEP_QUES );
         }
-        return true;
+        
+        for( unsigned int i=0; i < params.size(); i++ )
+        {
+            if ( std::string::npos != nPos || i!=0 ) {
+                encodedUrl.append( twitCurlDefaults::TWITCURL_URL_SEP_AMP ); 
+            }
+            encodedUrl.append( params.at( i ).key );
+            encodedUrl.append( twitCurlDefaults::TWITCURL_URL_EQUAL );
+            encodedUrl.append( urlencode( params.at( i ).value ) );
+        }
     }
+    curl_easy_setopt( m_curlHandle, CURLOPT_URL, encodedUrl.c_str() );
+
+    /* Send http request */
+    CURLcode res = curl_easy_perform( m_curlHandle );
     if( pOAuthHeaderList )
     {
         curl_slist_free_all( pOAuthHeaderList );
     }
+    if( CURLE_OK == res )
+        return true;
     return false;
+}
+
+/*++
+* @method: twitCurl::performGet
+*
+* @description: method to send http GET request. this is an internal method.
+*               twitcurl users should not use this method.
+*
+* @input: getUrl - url
+*
+* @output: none
+*
+* @remarks: internal method
+*
+*--*/
+bool twitCurl::performGet( const std::string& getUrl )
+{
+    httpParams params;
+    return performGet( getUrl, params );
 }
 
 /*++
@@ -1948,6 +2029,7 @@ bool twitCurl::performDelete( const std::string& deleteUrl )
     }
 
     std::string dataStrDummy;
+    httpParams paramDummy;
     std::string oAuthHttpHeader;
     struct curl_slist* pOAuthHeaderList = NULL;
 
@@ -1955,7 +2037,7 @@ bool twitCurl::performDelete( const std::string& deleteUrl )
     prepareStandardParams();
 
     /* Set OAuth header */
-    m_oAuth.getOAuthHeader( eOAuthHttpDelete, deleteUrl, dataStrDummy, oAuthHttpHeader );
+    m_oAuth.getOAuthHeader( eOAuthHttpDelete, deleteUrl, paramDummy, dataStrDummy, oAuthHttpHeader );
     if( oAuthHttpHeader.length() )
     {
         pOAuthHeaderList = curl_slist_append( pOAuthHeaderList, oAuthHttpHeader.c_str() );
@@ -2012,12 +2094,13 @@ bool twitCurl::performPost( const std::string& postUrl, std::string dataStr )
 
     std::string oAuthHttpHeader;
     struct curl_slist* pOAuthHeaderList = NULL;
+    httpParams paramDummy;
 
     /* Prepare standard params */
     prepareStandardParams();
 
     /* Set OAuth header */
-    m_oAuth.getOAuthHeader( eOAuthHttpPost, postUrl, dataStr, oAuthHttpHeader );
+    m_oAuth.getOAuthHeader( eOAuthHttpPost, postUrl, paramDummy, dataStr, oAuthHttpHeader );
     if( oAuthHttpHeader.length() )
     {
         pOAuthHeaderList = curl_slist_append( pOAuthHeaderList, oAuthHttpHeader.c_str() );
@@ -2145,10 +2228,12 @@ bool twitCurl::oAuthRequestToken( std::string& authorizeUrl /* out */ )
 
     /* Get OAuth header for request token */
     std::string oAuthHeader;
+    httpParams paramDummy;
     authorizeUrl = "";
     if( m_oAuth.getOAuthHeader( eOAuthHttpGet,
                                 twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
                                 oAuthTwitterApiUrls::OAUTHLIB_TWITTER_REQUEST_TOKEN_URL,
+                                paramDummy,
                                 std::string( "" ),
                                 oAuthHeader ) )
     {
@@ -2195,9 +2280,11 @@ bool twitCurl::oAuthAccessToken()
     }
     /* Get OAuth header for access token */
     std::string oAuthHeader;
+    httpParams paramDummy;
     if( m_oAuth.getOAuthHeader( eOAuthHttpGet,
                                 twitCurlDefaults::TWITCURL_PROTOCOLS[m_eProtocolType] +
                                 oAuthTwitterApiUrls::OAUTHLIB_TWITTER_ACCESS_TOKEN_URL,
+                                paramDummy,
                                 std::string( "" ),
                                 oAuthHeader, true ) )
     {
@@ -2237,6 +2324,7 @@ bool twitCurl::oAuthHandlePIN( const std::string& authorizeUrl /* in */ )
     }
 
     std::string dataStr;
+    httpParams paramDummy;
     std::string oAuthHttpHeader;
     std::string authenticityTokenVal;
     std::string oauthTokenVal;
@@ -2250,7 +2338,7 @@ bool twitCurl::oAuthHandlePIN( const std::string& authorizeUrl /* in */ )
     prepareStandardParams();
 
     /* Set OAuth header */
-    m_oAuth.getOAuthHeader( eOAuthHttpGet, authorizeUrl, dataStr, oAuthHttpHeader );
+    m_oAuth.getOAuthHeader( eOAuthHttpGet, authorizeUrl, paramDummy, dataStr, oAuthHttpHeader );
     if( oAuthHttpHeader.length() )
     {
         pOAuthHeaderList = curl_slist_append( pOAuthHeaderList, oAuthHttpHeader.c_str() );
@@ -2325,7 +2413,7 @@ bool twitCurl::oAuthHandlePIN( const std::string& authorizeUrl /* in */ )
               oAuthLibDefaults::OAUTHLIB_SESSIONPASSWORD_KEY + "=" + getTwitterPassword();
 
     /* Set OAuth header */
-    m_oAuth.getOAuthHeader( eOAuthHttpPost, authorizeUrl, dataStr, oAuthHttpHeader );
+    m_oAuth.getOAuthHeader( eOAuthHttpPost, authorizeUrl, paramDummy, dataStr, oAuthHttpHeader );
     if( oAuthHttpHeader.length() )
     {
         pOAuthHeaderList = curl_slist_append( pOAuthHeaderList, oAuthHttpHeader.c_str() );
@@ -2376,4 +2464,3 @@ bool twitCurl::oAuthHandlePIN( const std::string& authorizeUrl /* in */ )
     }
     return false;
 }
-

--- a/libtwitcurl/twitcurl.h
+++ b/libtwitcurl/twitcurl.h
@@ -185,6 +185,7 @@ private:
     void prepareCurlUserPass();
     void prepareStandardParams();
     bool performGet( const std::string& getUrl );
+    bool performGet( const std::string& getUrl, const httpParams& params );
     bool performGetInternal( const std::string& getUrl,
                              const std::string& oAuthHttpHeader );
     bool performDelete( const std::string& deleteUrl );

--- a/libtwitcurl/twitcurlurls.h
+++ b/libtwitcurl/twitcurlurls.h
@@ -14,33 +14,34 @@ namespace twitCurlDefaults
     const unsigned int MAX_TIMELINE_TWEET_COUNT = 200;
 
     /* Miscellaneous data used to build twitter URLs*/
-    const std::string TWITCURL_STATUSSTRING = "status=";
-    const std::string TWITCURL_TEXTSTRING = "text=";
-    const std::string TWITCURL_QUERYSTRING = "query=";
-    const std::string TWITCURL_SEARCHQUERYSTRING = "q=";
-    const std::string TWITCURL_SCREENNAME = "screen_name=";
-    const std::string TWITCURL_USERID = "user_id=";
+    const std::string TWITCURL_STATUSSTRING = "status";
+    const std::string TWITCURL_TEXTSTRING = "text";
+    const std::string TWITCURL_QUERYSTRING = "query";
+    const std::string TWITCURL_SEARCHQUERYSTRING = "q";
+    const std::string TWITCURL_SCREENNAME = "screen_name";
+    const std::string TWITCURL_USERID = "user_id";
     const std::string TWITCURL_EXTENSIONFORMATS[2] = { ".json",
                                                        ".xml"
                                                      };
     const std::string TWITCURL_PROTOCOLS[2] =        { "https://",
                                                        "http://"
                                                      };
-    const std::string TWITCURL_TARGETSCREENNAME = "target_screen_name=";
-    const std::string TWITCURL_TARGETUSERID = "target_id=";
-    const std::string TWITCURL_SINCEID = "since_id=";
-    const std::string TWITCURL_TRIMUSER = "trim_user=true";
-    const std::string TWITCURL_INCRETWEETS = "include_rts=true";
-    const std::string TWITCURL_COUNT = "count=";
-    const std::string TWITCURL_NEXT_CURSOR = "cursor=";
-    const std::string TWITCURL_SKIP_STATUS = "skip_status=";
-    const std::string TWITCURL_INCLUDE_ENTITIES = "include_entities=";
-    const std::string TWITCURL_STRINGIFY_IDS = "stringify_ids=";
-    const std::string TWITCURL_INREPLYTOSTATUSID = "in_reply_to_status_id=";
+    const std::string TWITCURL_TARGETSCREENNAME = "target_screen_name";
+    const std::string TWITCURL_TARGETUSERID = "target_id";
+    const std::string TWITCURL_SINCEID = "since_id";
+    const std::string TWITCURL_TRIMUSER = "trim_user";
+    const std::string TWITCURL_INCRETWEETS = "include_rts";
+    const std::string TWITCURL_COUNT = "count";
+    const std::string TWITCURL_NEXT_CURSOR = "cursor";
+    const std::string TWITCURL_SKIP_STATUS = "skip_status";
+    const std::string TWITCURL_INCLUDE_ENTITIES = "include_entities";
+    const std::string TWITCURL_STRINGIFY_IDS = "stringify_ids";
+    const std::string TWITCURL_INREPLYTOSTATUSID = "in_reply_to_status_id";
 
     /* URL separators */
     const std::string TWITCURL_URL_SEP_AMP = "&";
     const std::string TWITCURL_URL_SEP_QUES = "?";
+    const std::string TWITCURL_URL_EQUAL = "=";
 };
 
 /* Default twitter URLs */


### PR DESCRIPTION


Currently, the get URL is not encoded.
If the getURL include blank, it will get nothing.
If the getURL include character '&', oAuth::buildOAuthRawDataKeyValPairs can't split key value pairs correctly.
In my fix, http parameters will be directly sent to a new function oAuth::buildOAuthHttpParameterKeyValPairs then used to be encoded as part of getURL.