### PR TITLE
Update with support for 280 character tweets

### DIFF
--- a/libtwitcurl/twitcurl.cpp
+++ b/libtwitcurl/twitcurl.cpp
@@ -639,6 +639,7 @@ bool twitCurl::mentionsGet( const std::string sinceId )
 *         tweetCount - Number of tweets to get. Max 200.
 *         userInfo - screen name or user id in string format,
 *         isUserId - true if userInfo contains an id
+*         includeExtended - set true to get tweets longer than 140 characters
 *
 * @output: true if GET is success, otherwise false. This does not check http
 *          response by twitter. Use getLastWebResponse() for that.
@@ -648,8 +649,10 @@ bool twitCurl::timelineUserGet( const bool trimUser,
                                 const bool includeRetweets,
                                 const unsigned int tweetCount,
                                 const std::string userInfo,
-                                const bool isUserId )
+                                const bool isUserId,
+                                const bool includeExtended )
 {
+  std::cout << "AY" << std::endl;
     /* Prepare URL */
     std::string buildUrl;
 
@@ -690,6 +693,11 @@ bool twitCurl::timelineUserGet( const bool trimUser,
     if( trimUser )
     {
         buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_AMP + twitCurlDefaults::TWITCURL_TRIMUSER;
+    }
+
+    if( includeExtended )
+    {
+        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_AMP + twitCurlDefaults::TWITCURL_INCLUDEEXTENDED;
     }
 
     /* Perform GET */

--- a/libtwitcurl/twitcurl.cpp
+++ b/libtwitcurl/twitcurl.cpp
@@ -682,6 +682,10 @@ bool twitCurl::timelineUserGet( const bool trimUser,
     {
         buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_AMP + twitCurlDefaults::TWITCURL_INCRETWEETS;
     }
+    else
+    {
+        buildUrl += twitCurlDefaults::TWITCURL_URL_SEP_AMP + twitCurlDefaults::TWITCURL_DINCRETWEETS;
+    }        
 
     if( trimUser )
     {

--- a/libtwitcurl/twitcurl.h
+++ b/libtwitcurl/twitcurl.h
@@ -62,7 +62,8 @@ public:
 	                      const bool includeRetweets /* in */,
                           const unsigned int tweetCount /* in */,
                           const std::string userInfo = "" /* in */,
-                          const bool isUserId = false /* in */ );
+                          const bool isUserId = false /* in */, 
+                          const bool includeExtended = false /* in */ );
     bool featuredUsersGet();
     bool mentionsGet( const std::string sinceId = "" /* in */ );
 

--- a/libtwitcurl/twitcurlurls.h
+++ b/libtwitcurl/twitcurlurls.h
@@ -38,6 +38,7 @@ namespace twitCurlDefaults
     const std::string TWITCURL_INCLUDE_ENTITIES = "include_entities=";
     const std::string TWITCURL_STRINGIFY_IDS = "stringify_ids=";
     const std::string TWITCURL_INREPLYTOSTATUSID = "in_reply_to_status_id=";
+    const std::string TWITCURL_INCLUDEEXTENDED = "tweet_mode=extended";
 
     /* URL separators */
     const std::string TWITCURL_URL_SEP_AMP = "&";

--- a/libtwitcurl/twitcurlurls.h
+++ b/libtwitcurl/twitcurlurls.h
@@ -31,6 +31,7 @@ namespace twitCurlDefaults
     const std::string TWITCURL_SINCEID = "since_id=";
     const std::string TWITCURL_TRIMUSER = "trim_user=true";
     const std::string TWITCURL_INCRETWEETS = "include_rts=true";
+    const std::string TWITCURL_DINCRETWEETS = "include_rts=false";
     const std::string TWITCURL_COUNT = "count=";
     const std::string TWITCURL_NEXT_CURSOR = "cursor=";
     const std::string TWITCURL_SKIP_STATUS = "skip_status=";


### PR DESCRIPTION
Since the 280 character tweet change, the JSON result has been changed to add an extended mode, and to read the full content of these new longer tweets, extended mode has to be specified in the API request. These changes allow users to turn on extended mode.